### PR TITLE
Support Attributes that Contain Periods

### DIFF
--- a/isolate-react/src/isolateComponent/nodeMatcher.test.tsx
+++ b/isolate-react/src/isolateComponent/nodeMatcher.test.tsx
@@ -121,5 +121,9 @@ describe('nodeMatcher', () => {
     shouldNotMatchReact('div[data-test-id=bar]', Example, {
       'data-test-id': 'foo',
     })
+
+    shouldMatchReact('[name=nested.field]', Example, {
+      name: 'nested.field',
+    })
   })
 })

--- a/isolate-react/src/isolateComponent/nodeMatcher.ts
+++ b/isolate-react/src/isolateComponent/nodeMatcher.ts
@@ -30,12 +30,13 @@ export const nodeMatcher = (spec: Selector | null | undefined): NodeMatcher => {
     if (spec.includes('#')) {
       return idMatcher(spec)
     }
-    if (spec.includes('.')) {
-      return classOrExactMatcher(spec)
-    }
 
     if (/\[.+\]/.test(spec)) {
       return propMatcher(spec)
+    }
+
+    if (spec.includes('.')) {
+      return classOrExactMatcher(spec)
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/davidmfoley/isolate-react/issues/25

This adds support so selectors using html attributes with periods are processed as expected. Before doing something like `isolated.findOne("[data-test=some.field]")` would try to process the selector as a class, rather than an attribute.